### PR TITLE
Use the Node.js ≥ v22 `module-sync` `exports` condition to link to ES…

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,18 +16,18 @@
 			"node": {
 				"types": "./index.d.ts",
 				"import": "./index.js",
-				"require": "./index.js"
+				"module-sync": "./index.js"
 			},
 			"default": {
 				"types": "./core.d.ts",
 				"import": "./core.js",
-				"require": "./core.js"
+				"module-sync": "./core.js"
 			}
 		},
 		"./core": {
 			"types": "./core.d.ts",
 			"import": "./core.js",
-			"require": "./core.js"
+			"module-sync": "./core.js"
 		}
 	},
 	"sideEffects": false,


### PR DESCRIPTION
As proposed: https://github.com/sindresorhus/file-type/pull/723#issuecomment-2597795641